### PR TITLE
Bookings por club

### DIFF
--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/dto/BookingDTO.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/dto/BookingDTO.java
@@ -1,5 +1,6 @@
 package com.mesumo.msbookings.models.dto;
 
+import com.mesumo.msbookings.models.entities.Participant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,15 +17,22 @@ import java.util.Set;
 public class BookingDTO {
 
     private Long id;
+
     private String name;
 
     private Long slotId;
+
+    private Long activityId;
+
+    private String activityName;
 
     private Long creatorId;
 
     private Long clubId;
 
     private String clubName;
+
+    private String neighborhoodName;
 
     private Long courtId;
 
@@ -34,7 +42,7 @@ public class BookingDTO {
 
     private Time endTime;
 
-    private int participants;
+    private Set<Participant> participants;
 
     private String message;
 

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/dto/FiltersDTO.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/dto/FiltersDTO.java
@@ -1,0 +1,22 @@
+package com.mesumo.msbookings.models.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+import java.util.Set;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class FiltersDTO {
+
+    Set<ActivityDTO> activities;
+    Set<String> neighborhood;
+
+    Set<Date> bookingDates;
+}

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/dto/UserDTO.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/dto/UserDTO.java
@@ -16,4 +16,6 @@ public class UserDTO {
 
     private String lastName;
 
+    private String email;
+
 }

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/entities/Booking.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/entities/Booking.java
@@ -26,11 +26,17 @@ public class Booking {
 
     private Long slotId;
 
+    private Long activityId;
+
+    private String activityName;
+
     private Long creatorId;
 
     private Long clubId;
 
     private String clubName;
+
+    private String neighborhoodName;
 
     private Long courtId;
 
@@ -40,7 +46,12 @@ public class Booking {
 
     private Time endTime;
 
-    private int participants;
+    @ManyToMany
+    @JoinTable(
+        name = "booking_participant",
+        joinColumns = @JoinColumn(name = "booking_id"),
+        inverseJoinColumns = @JoinColumn(name = "participant_id"))
+    private Set<Participant> participants;
 
     private String message;
 

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/entities/Participant.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/entities/Participant.java
@@ -1,0 +1,35 @@
+package com.mesumo.msbookings.models.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class Participant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private Long userId;
+
+        private String firstName;
+
+        private String lastName;
+
+        private String email;
+
+    public Participant(Long id, String firstName, String lastName, String email) {
+        this.userId = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email=email;
+    }
+}

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/repository/IParticipantRepository.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/repository/IParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.mesumo.msbookings.models.repository;
+
+import com.mesumo.msbookings.models.entities.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IParticipantRepository extends JpaRepository<Participant, Long> {
+}

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/repository/feign/IUserFeignClient.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/repository/feign/IUserFeignClient.java
@@ -6,10 +6,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(url = "http://ec2-3-85-198-231.compute-1.amazonaws.com:8081/user", name = "ms-users", configuration = FeignConfig.class)
+@FeignClient(name = "ms-users", configuration = FeignConfig.class)
 public interface IUserFeignClient {
 
-    @GetMapping("/{id}")
+    @GetMapping("/user/{id}")
     UserDTO getById(@PathVariable Long id);
 
 }

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/IAvailabilityService.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/IAvailabilityService.java
@@ -9,5 +9,5 @@ import java.util.Map;
 
 public interface IAvailabilityService {
 
-    Map<LocalDate, Map<CourtDTO, List<SlotWithoutDaysDTO>>> getAvailableBookings(Long clubId, String activityName);
+    Map<LocalDate, Map<CourtDTO, List<SlotWithoutDaysDTO>>> getAvailableBookings(Long clubId, Long activityId);
 }

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/IBookingService.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/IBookingService.java
@@ -11,14 +11,15 @@ public interface IBookingService {
 
     Booking findById(Long id) throws ResourceNotFoundException;
     Booking create(Booking booking);
+    
     void deleteById(Long id) throws ResourceNotFoundException;
     Booking update(Booking booking) throws ResourceNotFoundException;
 
     Set<Booking> findAll();
 
     List<Booking> filterBooking(Specification spec);
-    List<Booking> filterByDate(LocalDate startDate, LocalDate endDate);
+    List<Booking> filterByDate(LocalDate startDate);
 
-    List<Booking> filterBySlotAndDate(Long slotId, LocalDate date, boolean approved);
+    List<Booking> filterBySlotAndDate(Long slotId, LocalDate date);
 
 }

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/IParticipantService.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/IParticipantService.java
@@ -1,0 +1,13 @@
+package com.mesumo.msbookings.models.service;
+
+import com.mesumo.msbookings.exceptions.ResourceNotFoundException;
+import com.mesumo.msbookings.models.entities.Participant;
+
+public interface IParticipantService {
+
+    Participant findById(Long id) throws ResourceNotFoundException;
+    Participant create(Participant participant);
+    Participant update(Participant participant);
+    void deleteById(Long id);
+
+}

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/impl/AvailabilityService.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/impl/AvailabilityService.java
@@ -23,13 +23,13 @@ public class AvailabilityService implements IAvailabilityService {
     IBookingService bookingService;
 
     @Override
-    public Map<LocalDate, Map<CourtDTO, List<SlotWithoutDaysDTO>>> getAvailableBookings(Long clubId, String activityName) {
+    public Map<LocalDate, Map<CourtDTO, List<SlotWithoutDaysDTO>>> getAvailableBookings(Long clubId, Long activityId) {
 
         ClubDTO club = clubFeignClient.getById(clubId);
 
         ActivityDTO selectedActivity = null;
         for (ActivityDTO activity : club.getActivities()) {
-            if (activity.getName().equals(activityName)) {
+            if (activity.getId().equals(activityId)) {
                 selectedActivity = activity;
                 break;
             }
@@ -54,7 +54,7 @@ public class AvailabilityService implements IAvailabilityService {
 
                 for (DayEntity day : slot.getDays()) {
                     LocalDate dateSlot = monthStart;
-                    List<Booking> bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot, true);
+                    List<Booking> bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot);
 
                     while (dateSlot.getDayOfWeek() != day.toJavaDayOfWeek()) {
                         dateSlot = dateSlot.plusDays(1);
@@ -71,7 +71,7 @@ public class AvailabilityService implements IAvailabilityService {
                         }
 
                         dateSlot = dateSlot.plusWeeks(1);
-                        bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot, true);
+                        bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot);
                     }
                     bookings = null;
                 }
@@ -81,13 +81,13 @@ public class AvailabilityService implements IAvailabilityService {
         return availabilityCalendar;
     }
 
-    public Map<CourtDTO, Map<LocalDate, List<SlotWithoutDaysDTO>>> getAvailableBookingsByCourt(Long clubId, Long courtId, String activityName) {
+    public Map<CourtDTO, Map<LocalDate, List<SlotWithoutDaysDTO>>> getAvailableBookingsByCourt(Long clubId, Long courtId, Long activityId) {
 
         ClubDTO club = clubFeignClient.getById(clubId);
 
         ActivityDTO selectedActivity = null;
         for (ActivityDTO activity : club.getActivities()) {
-            if (activity.getName().equals(activityName)) {
+            if (activity.getId().equals(activityId)) {
                 selectedActivity = activity;
                 break;
             }
@@ -124,7 +124,7 @@ public class AvailabilityService implements IAvailabilityService {
 
             for (DayEntity day : slot.getDays()) {
                 LocalDate dateSlot = monthStart;
-                List<Booking> bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot, true);
+                List<Booking> bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot);
 
                 while (dateSlot.getDayOfWeek() != day.toJavaDayOfWeek()) {
                     dateSlot = dateSlot.plusDays(1);
@@ -144,7 +144,7 @@ public class AvailabilityService implements IAvailabilityService {
                     }
 
                     dateSlot = dateSlot.plusWeeks(1);
-                    bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot, true);
+                    bookings = bookingService.filterBySlotAndDate(slot.getId(), dateSlot);
                 }
                 bookings = null;
             }

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/impl/BookingService.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/impl/BookingService.java
@@ -1,21 +1,34 @@
 package com.mesumo.msbookings.models.service.impl;
 
 import com.mesumo.msbookings.exceptions.ResourceNotFoundException;
+import com.mesumo.msbookings.models.dto.ActivityDTO;
+import com.mesumo.msbookings.models.dto.FiltersDTO;
+import com.mesumo.msbookings.models.dto.UserDTO;
 import com.mesumo.msbookings.models.entities.Booking;
+import com.mesumo.msbookings.models.entities.Participant;
 import com.mesumo.msbookings.models.repository.IBookingRepository;
+import com.mesumo.msbookings.models.repository.feign.IUserFeignClient;
 import com.mesumo.msbookings.models.service.IBookingService;
+import com.mesumo.msbookings.models.service.IParticipantService;
 import com.mesumo.msbookings.searchs.BookingSpecification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class BookingService implements IBookingService {
 
     @Autowired
     IBookingRepository bookingRepository;
+
+    @Autowired
+    IParticipantService participantService;
+
+    @Autowired
+    IUserFeignClient userFeignClient;
 
     @Override
     public Booking findById(Long id) throws ResourceNotFoundException {
@@ -28,8 +41,13 @@ public class BookingService implements IBookingService {
 
     @Override
     public Booking create(Booking booking) {
+        UserDTO creator = userFeignClient.getById(booking.getCreatorId());
+        Participant firstParticipant = new Participant(booking.getCreatorId(), creator.getFirstName(), creator.getLastName(), creator.getEmail());
+        booking.getParticipants().add(firstParticipant);
+        participantService.create(firstParticipant);
         return bookingRepository.save(booking);
     }
+
 
     @Override
     public void deleteById(Long id) throws ResourceNotFoundException {
@@ -53,11 +71,20 @@ public class BookingService implements IBookingService {
             if (booking.getSlotId() != null){
                 newBooking.get().setSlotId(booking.getSlotId());
             }
+            if (booking.getActivityId() != null){
+                newBooking.get().setActivityId(booking.getActivityId());
+            }
+            if (booking.getActivityName() != null){
+                newBooking.get().setActivityName(booking.getActivityName());
+            }
             if (booking.getCreatorId() != null){
                 newBooking.get().setCreatorId(booking.getCreatorId());
             }
             if (booking.getClubId() != null){
                 newBooking.get().setClubId(booking.getClubId());
+            }
+            if (booking.getNeighborhoodName() != null){
+                newBooking.get().setNeighborhoodName(booking.getNeighborhoodName());
             }
             if (booking.getCourtId() != null){
                 newBooking.get().setCourtId(booking.getCourtId());
@@ -71,7 +98,7 @@ public class BookingService implements IBookingService {
             if (booking.getEndTime() != null){
                 newBooking.get().setEndTime(booking.getEndTime());
             }
-            if (booking.getParticipants() != 0){
+            if (!booking.getParticipants().equals(newBooking.get().getParticipants())){
                 newBooking.get().setParticipants(booking.getParticipants());
             }
             if (booking.getMessage() != null){
@@ -100,16 +127,17 @@ public class BookingService implements IBookingService {
     }
 
     @Override
-    public List<Booking> filterByDate(LocalDate startDate, LocalDate endDate) {
+    public List<Booking> filterByDate(LocalDate startDate) {
         return null;
     }
 
     @Override
-    public List<Booking> filterBySlotAndDate(Long slotId, LocalDate date, boolean approved) {
+    public List<Booking> filterBySlotAndDate(Long slotId, LocalDate date) {
         Specification<Booking> spec = new BookingSpecification();
-        spec = spec.and(BookingSpecification.bookingsBySlotAndDate(slotId, date, approved));
+        spec = spec.and(BookingSpecification.bookingsBySlotAndDate(slotId, date));
         return filterBooking(spec);
     }
+
 
     public List<Booking> filterByApproved(boolean approved) {
         Specification<Booking> spec = new BookingSpecification();
@@ -123,5 +151,128 @@ public class BookingService implements IBookingService {
         spec = spec.and(BookingSpecification.bookingsByClub(clubId));
         return filterBooking(spec);
     }
+
+    public List<Booking> filterByCreatorUser(Long userId) {
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsByCreatorUser(userId));
+        return filterBooking(spec);
+    }
+
+    public List<Booking> filterByUserParticipant(Long userId) {
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsByUserParticipant(userId));
+        return filterBooking(spec);
+    }
+
+    public List<Booking> filterByClubAndUserParticipant(Long clubId, Long userId) {
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsByClub(clubId));
+        spec = spec.and(BookingSpecification.bookingsByUserParticipant(userId));
+        return filterBooking(spec);
+    }
+
+    public List<Booking> filterByClubAndCreatorUser(Long clubId, Long userId) {
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsByClub(clubId));
+        spec = spec.and(BookingSpecification.bookingsByCreatorUser(userId));
+        return filterBooking(spec);
+    }
+
+    public FiltersDTO filtersActivity(Long activityId) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByActivities(activityId));
+        List<Booking> bookings = filterBooking(spec);
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO filtersActivityAndNeighborhood(Long activityId, String neighborhood) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByActivities(activityId));
+        spec = spec.and(BookingSpecification.bookingsByNeighborhood(neighborhood));
+
+        List<Booking> bookings = filterBooking(spec);
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO filtersActivityAndDate(Long activityId, LocalDate date) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByActivities(activityId));
+        spec = spec.and(BookingSpecification.bookingsByDate(date));
+        List<Booking> bookings = filterBooking(spec);
+
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO filtersNeighborhood(String neighborhood) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByNeighborhood(neighborhood));
+        List<Booking> bookings = filterBooking(spec);
+
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO filtersNeighborhoodAndDate(String neighborhood, LocalDate date) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByNeighborhood(neighborhood));
+        spec = spec.and(BookingSpecification.bookingsByDate(date));
+        List<Booking> bookings = filterBooking(spec);
+
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO filtersDate(LocalDate date) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByDate(date));
+        List<Booking> bookings = filterBooking(spec);
+
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO filtersActivityAndNeighborhoodAndDate(Long activityId, String neighborhood, LocalDate date) {
+        FiltersDTO filters = new FiltersDTO();
+        Specification<Booking> spec = new BookingSpecification();
+        spec = spec.and(BookingSpecification.bookingsApproved(false));
+        spec = spec.and(BookingSpecification.bookingsByActivities(activityId));
+        spec = spec.and(BookingSpecification.bookingsByNeighborhood(neighborhood));
+        spec = spec.and(BookingSpecification.bookingsByDate(date));
+        List<Booking> bookings = filterBooking(spec);
+
+        return returnFilters(bookings, filters);
+    }
+
+    public FiltersDTO returnFilters (List<Booking> bookings, FiltersDTO filters) {
+        filters.setNeighborhood(bookings.stream()
+                .map(Booking::getNeighborhoodName)
+                .collect(Collectors.toSet()));
+        filters.setActivities(bookings.stream()
+                .map(booking -> {
+                    ActivityDTO activity = new ActivityDTO();
+                    activity.setId(booking.getActivityId());
+                    activity.setName(booking.getActivityName());
+                    return activity;
+                })
+                .collect(Collectors.toSet()));
+        filters.setBookingDates(bookings.stream()
+                .map(Booking ::getDate)
+                .collect(Collectors.toSet()));
+
+        return filters;
+    }
+
+
+
+
 
 }

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/impl/ParticipantService.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/models/service/impl/ParticipantService.java
@@ -1,0 +1,41 @@
+package com.mesumo.msbookings.models.service.impl;
+
+import com.mesumo.msbookings.exceptions.ResourceNotFoundException;
+import com.mesumo.msbookings.models.entities.Participant;
+import com.mesumo.msbookings.models.repository.IParticipantRepository;
+import com.mesumo.msbookings.models.service.IParticipantService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ParticipantService implements IParticipantService {
+
+    @Autowired
+    IParticipantRepository repository;
+
+    @Override
+    public Participant findById(Long id) throws ResourceNotFoundException {
+        Optional<Participant> participant = repository.findById(id);
+        if(participant.isEmpty()){
+            throw new ResourceNotFoundException("Participant not found");
+        }
+        return participant.get();
+    }
+
+    @Override
+    public Participant create(Participant participant) {
+        return repository.save(participant);
+    }
+
+    @Override
+    public Participant update(Participant participant) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/ms-bookings/src/main/java/com/mesumo/msbookings/searchs/BookingSpecification.java
+++ b/backend/ms-bookings/src/main/java/com/mesumo/msbookings/searchs/BookingSpecification.java
@@ -18,12 +18,11 @@ public class BookingSpecification implements Specification<Booking> {
 
     }
 
-    public static Specification<Booking> bookingsBySlotAndDate(Long slotId, LocalDate date, boolean approved) {
+    public static Specification<Booking> bookingsBySlotAndDate(Long slotId, LocalDate date) {
         return (root, query, criteriaBuilder) -> {
             return criteriaBuilder.and(
                     criteriaBuilder.equal(root.get("slotId"), slotId),
-                    criteriaBuilder.equal(root.get("date"), date),
-                    criteriaBuilder.equal(root.get("approved"), approved));
+                    criteriaBuilder.equal(root.get("date"), date));
         };
     }
 
@@ -38,6 +37,40 @@ public class BookingSpecification implements Specification<Booking> {
         return (root, query, criteriaBuilder) -> {
             return criteriaBuilder.and(
                     criteriaBuilder.equal(root.get("clubId"), clubId));
+        };
+    }
+    public static Specification<Booking> bookingsByCreatorUser(Long userId) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("creatorId"), userId));
+        };
+    }
+
+    public static Specification<Booking> bookingsByUserParticipant(Long userId) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("participants"), userId));
+        };
+    }
+
+    public static Specification<Booking> bookingsByActivities(Long activityId) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("activityId"), activityId));
+        };
+    }
+
+    public static Specification<Booking> bookingsByNeighborhood(String neighborhood) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("neighborhoodName"), neighborhood));
+        };
+    }
+
+    public static Specification<Booking> bookingsByDate(LocalDate date) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("date"), date));
         };
     }
 


### PR DESCRIPTION
Cambios realizados:

- Ahora los participantes se agregan mediante una relación muchos a muchos con las bookings y se almacenan en una tabla Participants del microservicio Bookings. De esta forma, se pueden recuperar fácilmente los participantes que se adhirieron a un determinado evento (aún queda por hacer la recuperación de eventos por usuario desde el microservicio de usuarios).
- Las actividades ya no se filtran por nombre de actividad, sino por id.
- Las disponibilidad de las canchas depende ahora de la creación del evento. Una vez que el evento ha sido creado, ya no es posible reservar la cancha para el mismo día y horario.
- Se agregó un endpoint (y el servicio correspondiente) para traer las disponibilidades por cancha ("/court_slots").
- Se agregaron los campos de neighborhoodName, ActivityId y ActivityName para facilitar el funcionamiento de los filtros. Se agrego un endpoint de filtros rápidos, para traer únicamente los datos necesarios que el front necesita en un objeto de tipo FiltersDTO.
Postman: 
[Bookings.postman_collection.json](https://github.com/aquamantop/Grupo-5/files/13468968/Bookings.postman_collection.json)
 